### PR TITLE
 Make RTOTimeout span all connection attempts

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -266,9 +266,7 @@ func CloseRepoPool() error {
 	return pool.RepoPool.CloseRepoPool()
 }
 
-func CheckPrimaryConnTime() (*time.Time, error) {
-
-	ctx, _ := context.WithTimeout(context.Background(), time.Duration(global.CliOpts.RTOTimeout)*time.Millisecond)
+func CheckPrimaryConnTime(ctx context.Context) (*time.Time, error) {
 	conn, err := pgx.Connect(ctx, global.CliOpts.PrimaryPgDsn)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Thank you for the great tool, we are using it to test our HA solution. While doing so I noticed that when a leader doesn't go back online PTOR loops forever without outputting anything. The problem is that the RTOTimeout gets reset for every connection attempt, so I made a patch that fixes it, so that the timeout spans all connection attempts, it works well for me and I thought it might be useful upstream as well.